### PR TITLE
Fix(sidebar): Prevent horizontal overflow in collapsed chats

### DIFF
--- a/components/chat-sidebar.tsx
+++ b/components/chat-sidebar.tsx
@@ -138,7 +138,10 @@ export function ChatSidebar() {
                     )}>
                         Chats
                     </SidebarGroupLabel>
-                    <SidebarGroupContent className="overflow-y-auto pt-1">
+                    <SidebarGroupContent className={cn(
+                        "overflow-y-auto pt-1",
+                        isCollapsed ? "overflow-x-hidden" : ""
+                    )}>
                         <SidebarMenu>
                             {isLoading ? (
                                 <div className={`flex items-center justify-center py-4 ${isCollapsed ? "" : "px-4"}`}>


### PR DESCRIPTION
This PR fixes horizontal scrollbars appearing on the collapsed chat list.

Before:
![image](https://github.com/user-attachments/assets/4b921924-1715-4735-8773-68fea2f323a7)

After:
![image](https://github.com/user-attachments/assets/4e450da5-99f0-4220-82cb-02c64d58db64)