### PR TITLE
Add GitMCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can use any MCP-compatible server with this application. Here are some examp
 
 - [Composio](https://composio.dev/mcp) - Provides search, code interpreter, and other tools
 - [Zapier MCP](https://zapier.com/mcp) - Provides access to Zapier tools
+- [GitMCP](https://gitmcp.io) - Provides a remote MCP server for any GitHub repo documentation
 - Any MCP server using stdio transport with npx and python3
 
 ## License


### PR DESCRIPTION
Add GitMCP as an example - https://gitmcp.io.

This is a remote, fully open-source, no installation instant documentation MCP server for any GitHub repo, just by changing `github.com` to `gitmcp.io.`
For example - https://gitmcp.io/remix-run/react-router is the MCP server for React Router. In addition - there's a generic server  - https://gitmcp.io/docs - that can handle requests for any repo.

**Note**: It's a remote SSE server, so it's very easy to add.

Here's an example when added to the chat:
<video src="https://github.com/user-attachments/assets/16ff946e-c70d-43e9-9b2f-aefd923d5030"></video>

**Github**: https://github.com/idosal/git-mcp